### PR TITLE
docs: modify twitter link Footer.vue

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -116,7 +116,7 @@ const navigation = [
 const social = [
   {
     label: "Twitter",
-    href: "https://twitter.com/startalehq",
+    href: "https://x.com/StartaleGroup",
     icon: Twitter,
   },
   // {


### PR DESCRIPTION
The old twitter link, "https://twitter.com/startalehq" is no longer active. Instead, modified the link to https://x.com/StartaleGroup".

Meanwhile, Twitter has rebranded as X. It's appropriate to call it X now, and the icon needs to change accordingly. It looks like this needs to be fixed as well.